### PR TITLE
fix THRESH comment

### DIFF
--- a/include/GlobalDefines.hpp
+++ b/include/GlobalDefines.hpp
@@ -46,7 +46,7 @@ uint64_t static inline GB(uint64_t value) {
 // number of rounds to hammer
 #define HAMMER_ROUNDS 1000000
 
-// threshold to distinguish between cache miss (t > THRESH) and cache hit (t < THRESH)
+// threshold to distinguish between row buffer miss (t > THRESH) and row buffer hit (t < THRESH)
 #define THRESH 495  // worked best on DIMM 6
 //#define THRESH 430  // worked best on DIMM 18
 


### PR DESCRIPTION
In my opinion, THRESH is the threshold to distinguish row buffer miss rather than cache miss since in function measure_time() each memory access is followed by a clflushopt to flush it from cache.